### PR TITLE
Disabled Streamlit telemetry & removed segment expander

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you're using conda, you can create a new environment with the following comma
 conda env create -f environment.yml
 ```
 
-Note: If you're using a CPU-only machine, your runtime can be sped-up by using quantization implemented by [@MicellaneousStuff](https://github.com/MiscellaneousStuff) by swapping out `pip install openai-whisper` from `requirements.txt` and replacing it with their fork `pip install git+https://github.com/MiscellaneousStuff/whisper.git` (See related discussion here - https://github.com/hayabhay/whisper-ui/issues/20) 
+Note: If you're using a CPU-only machine, your runtime can be sped-up by using quantization implemented by [@MicellaneousStuff](https://github.com/MiscellaneousStuff) by swapping out `pip install openai-whisper` from `requirements.txt` and replacing it with their fork `pip install git+https://github.com/MiscellaneousStuff/whisper.git` (See related discussion here - https://github.com/hayabhay/whisper-ui/issues/20)
 
 ## Usage
 

--- a/app/.streamlit/config.toml
+++ b/app/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[browser]
+gatherUsageStats = false

--- a/app/01_🏠_Home.py
+++ b/app/01_🏠_Home.py
@@ -277,21 +277,18 @@ else:
         st.markdown(media["transcript"])
         st.write("---")
 
-    with st.expander("📝 &nbsp; Segments", expanded=True):
-        st.info(
-            """Clicking on a segment will move start position to the segment (only audio player will continue playing while video will pause)"""
-        )
-        # Iterate over all segments in the transcript
-        for segment in media["segments"]:
-            # Create 2 columns
-            meta_col, text_col = st.columns([1, 6], gap="small")
+    st.info(
+        """Clicking on a segment will move start position to the segment (only audio player will continue playing while video will pause)"""
+    )
+    # Iterate over all segments in the transcript
+    for segment in media["segments"]:
+        # Create 2 columns
+        meta_col, text_col = st.columns([1, 6], gap="small")
 
-            with meta_col:
-                if st.button(
-                    f"▶️ &nbsp; {int(segment['start'])}: {int(segment['end'])}", key=f"play-{segment['number']}"
-                ):
-                    st.session_state.selected_media_offset = int(segment["start"])
-                    st.experimental_rerun()
+        with meta_col:
+            if st.button(f"▶️ &nbsp; {int(segment['start'])}: {int(segment['end'])}", key=f"play-{segment['number']}"):
+                st.session_state.selected_media_offset = int(segment["start"])
+                st.experimental_rerun()
 
-            with text_col:
-                st.write(f'##### `{segment["text"]}`')
+        with text_col:
+            st.write(f'##### `{segment["text"]}`')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ openai-whisper==20230124 # https://github.com/openai/whisper
 # Backend
 # --------------------
 pytube==12.1.2 # https://github.com/pytube/pytube
-SQLAlchemy==2.0.2 # https://github.com/sqlalchemy/sqlalchemy
+SQLAlchemy==2.0.3 # https://github.com/sqlalchemy/sqlalchemy
 
 # Frontend
 # --------------------
-streamlit==1.17.0 # https://github.com/streamlit/streamlit
+streamlit==1.18.1 # https://github.com/streamlit/streamlit


### PR DESCRIPTION
Two small changes
1. Disabled Streamlit's default telemetry in `.streamlit/config.toml`
2. Removed `st.expander` for detail view
    - Streamlit's column creation is very slow and when the number of segments range in the ~100s, creating this has a pretty big compute cost
    -  Streamlit's expander triggers the above creation & deletion every time the html is collapsed/expanded instead of simply hiding visibility. This entails the repetition of this expensive column creation. So for now, at the very least, expander is removed so the play button & segment text rendering is a one time operation per detail view.