### PR TITLE
Fix No module named 'altair.vegalite.v4'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ SQLAlchemy==2.0.3 # https://github.com/sqlalchemy/sqlalchemy
 # Frontend
 # --------------------
 streamlit==1.18.1 # https://github.com/streamlit/streamlit
+altair<5 # Fix issue "No module named 'altair.vegalite.v4'"


### PR DESCRIPTION
Fixed issue No module named 'altair.vegalite.v4' on Docker See https://discuss.streamlit.io/t/modulenotfounderror-no-module-named-altair-vegalite-v4/42921/11